### PR TITLE
fix: remove typoed exrpess dependency

### DIFF
--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -665,11 +665,6 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
-    "node_modules/exrpess": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/exrpess/-/exrpess-0.0.1-security.tgz",
-      "integrity": "sha512-BFgbLPWkXVkKrWcRDObywcWQJrCROtTRyj330Db2jmYqoKN4tSSP+Ya4RzZMSkcpRNTTicr3nzcgJqFCasGpzw=="
-    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",

--- a/backend/node_modules/exrpess/README.md
+++ b/backend/node_modules/exrpess/README.md
@@ -1,9 +1,0 @@
-# Security holding package
-
-This package name is not currently in use, but was formerly occupied
-by another package. To avoid malicious use, npm is hanging on to the
-package name, but loosely, and we'll probably give it to you if you
-want it.
-
-You may adopt this package by contacting support@npmjs.com and
-requesting the name.

--- a/backend/node_modules/exrpess/package.json
+++ b/backend/node_modules/exrpess/package.json
@@ -1,6 +1,0 @@
-{
-  "name": "exrpess",
-  "version": "0.0.1-security",
-  "description": "security holding package",
-  "repository": "npm/security-holder"
-}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,6 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "express-session": "^1.18.2",
-        "exrpess": "^0.0.1-security",
         "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "sequelize": "^6.37.7",
@@ -684,11 +683,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/exrpess": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/exrpess/-/exrpess-0.0.1-security.tgz",
-      "integrity": "sha512-BFgbLPWkXVkKrWcRDObywcWQJrCROtTRyj330Db2jmYqoKN4tSSP+Ya4RzZMSkcpRNTTicr3nzcgJqFCasGpzw=="
     },
     "node_modules/finalhandler": {
       "version": "2.1.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,6 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "express-session": "^1.18.2",
-    "exrpess": "^0.0.1-security",
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "sequelize": "^6.37.7",


### PR DESCRIPTION
## Summary
- remove unintended `exrpess` dependency from backend package
- update lock files accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68983a93af3c8325ab05775704dd7a11